### PR TITLE
Option to save time derivative

### DIFF
--- a/equation.cxx
+++ b/equation.cxx
@@ -58,6 +58,10 @@ Equation::Equation(Field3D& f_ref, const std::string& f_name, Options& opt,
       or options["save_all_terms_" + name].withDefault(false)) {
     save_equation = true;
   }
+
+  if (options["save_ddt"].withDefault(false)) {
+    output_file.addRepeat(ddt(f), name);
+  }
 }
 
 EquationTerm& Equation::operator[](const std::string& term_name) {


### PR DESCRIPTION
Add option to save the time derivative (i.e. the sum of all `EquationTerms`). Can be used for either value of `save_all_terms`.